### PR TITLE
utilisateur geonetwork pour mettre à jour la base de données geonetwork

### DIFF
--- a/bin/lib/metadata_2_gn.py
+++ b/bin/lib/metadata_2_gn.py
@@ -248,7 +248,7 @@ def publish_2_gn(input, url, login, password, workspace, database_hostname, verb
     sql_file = open(sql_file_name,"w")
     sql_file.write(sql_req)
     sql_file.close()
-    os.system("psql -h " + database_hostname + " -d georchestra -U geosync -a -f " + sql_file_name)
+    os.system("psql -h " + database_hostname + " -d georchestra -U geonetwork -w -a -f " + sql_file_name)
 
 
 


### PR DESCRIPTION
c'est l'utilisateur geonetwork qui met à jour le schéma geonetwork de la base de données georchestra.
l'option -w est nécessaire pour prendre en compte le mot de passe disposible dans .pgpass.

un préalable pour que cela fonctionne : l'utilisateur georchestra-ouvert doit avoir le rôle GN_EDITOR.